### PR TITLE
Add support for custom AWS profiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,26 @@ hosted within CodeArtifact. It will use any appropriate AWS credentials provided
 ```
 --index-url https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/pypi/${REPOSITORY}/simple/
 ```
+
+Config
+------
+This backend provides a number of configuration options to allow configuration of the aws credentials.
+
+Configuration is specified within a `[codeartifact]` section of the the `keyring` library config file.
+Run `keyring diagnose` to find its as the location can be different depending on the platform.
+
+
+### Options
+- `aws_access_key_id` Specifies the key ID used to authenticate with AWS.
+- `aws_secret_access_key` Specifies the secret key used to authenticate with AWS.
+- `profile_name` Specifies the name of a specific profile to use with the AWS client.
+
+For more explanation of these options see the [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
+
+Example:
+```ini
+[codeartifact]
+profile_name=profile_name
+aws_access_key_id=xxxxxxxxx
+aws_secret_access_key=xxxxxxxxx
+```

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ hosted within CodeArtifact. It will use any appropriate AWS credentials provided
 
 Config
 ------
-This backend provides a number of configuration options to allow configuration of the aws credentials.
+This backend provides a number of configuration options to modify the behaviour of the AWS client.
 
-Configuration is specified within a `[codeartifact]` section of the the `keyring` library config file.
-Run `keyring diagnose` to find its as the location can be different depending on the platform.
+These configuration options can be specified within a `[codeartifact]` section of the `keyringrc.cfg`.
+
+Run `keyring diagnose` to find its as the location; it varies between different platforms.
 
 
 ### Options

--- a/keyrings/codeartifact.py
+++ b/keyrings/codeartifact.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from functools import cache
 import os
 import re
 import logging
@@ -12,6 +11,7 @@ from keyring import backend
 from keyring import credentials
 from keyring.util.platform_ import config_root
 
+from functools import cache
 from datetime import datetime
 from urllib.parse import urlparse
 


### PR DESCRIPTION
This change allows specification of the AWS profile to use for code artefact logins. At the moment this only supports a single value but in future could be expanded to make the selection based on the input URIs domain / account / region.