### PR TITLE
fix: Update package name extraction from codeartifact path

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -24,9 +24,13 @@ def backend():
     keyring.set_keyring(original)
 
 
-def codeartifact_pypi_url(domain, owner, region, name):
+def codeartifact_url(domain, owner, region, path):
     netloc = f"{domain}-{owner}.d.codeartifact.{region}.amazonaws.com"
-    return urlunparse(("https", netloc, f"/pypi/{name}", "", "", ""))
+    return urlunparse(("https", netloc, path, "", "", ""))
+
+
+def codeartifact_pypi_url(domain, owner, region, name):
+    return codeartifact_url(domain, owner, region, f"/pypi/{name}/simple/")
 
 
 def test_set_password_raises(backend):
@@ -44,11 +48,22 @@ def test_delete_password_raises(backend):
     [
         "https://example.com/",
         "https://unknown.amazonaws.com/",
-        codeartifact_pypi_url("domain", "000000000000", "region", "/"),
-        codeartifact_pypi_url("domain", "owner", "region", "/maven/repo"),
+        codeartifact_url("domain", "owner", "region", "/maven/repo/"),
     ],
 )
 def test_get_credential_unsupported_host(backend, service):
+    assert not keyring.get_credential(service, None)
+
+
+@pytest.mark.parametrize(
+    "service",
+    [
+        codeartifact_url("domain", "000000000000", "region", "/pkg"),
+        codeartifact_url("domain", "000000000000", "region", "/pypi/pkg"),
+        codeartifact_url("domain", "000000000000", "region", "/pkg/simple/"),
+    ],
+)
+def test_get_credential_invalid_path(backend, service):
     assert not keyring.get_credential(service, None)
 
 


### PR DESCRIPTION
When we added support for multiple configuration sections in commit 46e83fe03a305da673b20e7e1da6a2a93c8b6b6d, we inadvertently broke the path parsing logic. A typical error would look something similar to this:

    too many values to unpack (expected 3)
    at ~/path/to/keyrings/codeartifact.py:151 in get_password
      150│ # Use the second and third parts as repository type and name.
    → 151│ _, repository_type, repository_name = parts

The core of the problem was that our code assumed that codeartifact paths look like /pypi/repo-name, but this assumption is false. Normally, what we see is actually /pypi/repo-name/simple/ as documented in the AWS documentation.

We also moved away from using PurePath to parse our paths. PurePath is OS-dependent and behaves differently based on the platform we currently run our Python interpretea on, but this is now what we want when parsing paths in urls. Since valid codeartifact paths have very little variety in them, we oped to parse them using a relatively simple regular expression.

Our regular expression for validating url paths is a bit less strict than what is described in AWS docs. The codeartifact docs state that all urls need to end with a /simple/ suffix or things will not work. But in practice, paths without a trailing / also work fine as redirect to /-suffixed path as required by PEP 503.