### PR TITLE
Allow Disabling SSL/TLS Verification.

### DIFF
--- a/keyrings/codeartifact.py
+++ b/keyrings/codeartifact.py
@@ -188,6 +188,19 @@ class CodeArtifactBackend(backend.KeyringBackend):
         if profile_name:
             options.update({"profile_name": profile_name})
 
+        # Provide option to disable SSL/TLS verification.
+        verify = config.get("verify")
+        if verify:
+            if verify.lower() in {"1", "yes", "on", "true"}:
+                # Enable SSL/TLS verification explicitly.
+                options.update({"verify": True})
+            elif verify.lower() in {"0", "no", "off", "false"}:
+                # Disable SSL/TLS verification entirely.
+                options.update({"verify": False})
+            else:
+                # The SSL/TLS certificate to verify against.
+                options.update({"verify": verify.strip('"')})
+
         # If static access/secret keys were provided, use them.
         aws_access_key_id = config.get("aws_access_key_id")
         aws_secret_access_key = config.get("aws_secret_access_key")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -183,6 +183,26 @@ def test_get_credential_supported_host():
                 "profile_name": "PROFILE-OVERRIDDEN",
             },
         ),
+        # Turning off SSL verification by default.
+        (
+            """
+            [codeartifact]
+            verify = off
+            """,
+            {
+                "verify": False,
+            },
+        ),
+        # Turning on SSL verification using a custom certificate.
+        (
+            """
+            [codeartifact]
+            verify = ./path/to/certificate.pem
+            """,
+            {
+                "verify": "./path/to/certificate.pem",
+            },
+        ),
     ],
 )
 def test_backend_default_options(configuration, assertions):


### PR DESCRIPTION
This PR implements support for disabling SSL/TLS verification and allowing for validation of self-signed certificates.

It adds a new `verify` option to the configuration file to match the `boto3.client()` keyword option:

```ini
; SSL/TLS verification is enabled by default if left unspecified.
[codeartifact]
; verify = true

; SSL/TLS verification can be disabled for individual accounts, etc.
[codeartifact account="66666666666"]
verify = false

; SSL/TLS verification can explicitly match a locally-stored CA certificate.
[codeartifact name="self-signed-certificate"]
verify = ./path/to/certificate.pem
```

This fixes #10.