### PR TITLE
Respect 'profile_name' Option in Configuration

### DIFF
--- a/keyrings/codeartifact.py
+++ b/keyrings/codeartifact.py
@@ -107,8 +107,12 @@ class CodeArtifactKeyringConfig:
 
 
 def make_codeartifact_client(options, **kwargs):
-    # Build a session for our client.
-    session = boto3.session.Session()
+    # Build a session with the provided options.
+    session = boto3.session.Session(
+        # NOTE: Only the session accepts 'profile_name'.
+        profile_name=kwargs.pop("profile_name", None),
+        region_name=kwargs.get("region_name"),
+    )
 
     # Create a client for this new session.
     return session.client("codeartifact", **options)

--- a/keyrings/codeartifact.py
+++ b/keyrings/codeartifact.py
@@ -146,7 +146,7 @@ class CodeArtifactBackend(backend.KeyringBackend):
 
         # If it didn't match the regex, it doesn't apply to us.
         if not host_match:
-            logging.warning("Not an AWS CodeArtifact repository URL!")
+            logging.warning(f"Not an AWS CodeArtifact repository URL: {service}")
             return
 
         # Extract the domain, account and region for this repository.

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -13,6 +13,9 @@ from pathlib import Path
 from urllib.parse import urlunparse
 from datetime import datetime, timedelta
 
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+
 from keyrings.codeartifact import CodeArtifactBackend, CodeArtifactKeyringConfig
 
 REGION_NAME = "ca-central-1"
@@ -34,37 +37,15 @@ def codeartifact_pypi_url(domain, owner, region, name):
     return codeartifact_url(domain, owner, region, f"/pypi/{name}/")
 
 
-class StubbingSession:
-    class Client:
-        def __init__(self, service, **kwargs):
-            self.client = boto3.client(service, **kwargs)
-            self.stub = botocore.stub.Stubber(self.client)
-
-        def stub():
-            return self.stub
-
-        def __getattr__(self, attr):
-            delegate = getattr(self.client, attr)
-
-            def wrapper(*args, **kwargs):
-                with self.stub as stub:
-                    return delegate(*args, **kwargs)
-
-            return delegate
-
-    def __init__(self, **kwargs):
-        self.default_kwargs = kwargs
-        self.clients = {}
-
-    def client(self, service, **client_kwargs):
-        kwargs = {}
-        kwargs.update(self.default_kwargs)
-        kwargs.update(client_kwargs)
-
-        if not self.clients.get(service):
-            self.clients[service] = StubbingSession.Client(service, **kwargs)
-
-        return self.clients[service]
+@contextmanager
+def config_from_string(content: str):
+    """
+    Generates a temporary configuration file from a string.
+    """
+    with NamedTemporaryFile(mode="w+") as cfg:
+        cfg.write(content)
+        cfg.flush()
+        yield cfg
 
 
 @pytest.fixture
@@ -112,27 +93,30 @@ def test_get_credential_invalid_path(default_backend, service):
 
 
 def test_get_credential_supported_host():
-    session = StubbingSession(region_name=REGION_NAME)
-    client = session.client("codeartifact", region_name=REGION_NAME)
+    def make_client(options, **kwargs):
+        client = boto3.client("codeartifact", **options)
+        stubber = botocore.stub.Stubber(client)
 
-    parameters = {
-        "domain": "domain",
-        "domainOwner": "000000000000",
-        "durationSeconds": 3600,
-    }
+        parameters = {
+            "domain": "domain",
+            "domainOwner": "000000000000",
+            "durationSeconds": 3600,
+        }
 
-    # The response we expect from the API.
-    response = {
-        "authorizationToken": "TOKEN",
-        # Compute the expiration based on the current timestamp.
-        "expiration": current_time() + timedelta(seconds=3600),
-    }
+        # The response we expect from the API.
+        response = {
+            "authorizationToken": "TOKEN",
+            # Compute the expiration based on the current timestamp.
+            "expiration": current_time() + timedelta(seconds=3600),
+        }
 
-    client.stub.add_response("get_authorization_token", response, parameters)
-    client.stub.activate()
+        stubber.add_response("get_authorization_token", response, parameters)
+        stubber.activate()
+
+        return client
 
     config = CodeArtifactKeyringConfig(config_file=StringIO())
-    backend = CodeArtifactBackend(config=config, session=session)
+    backend = CodeArtifactBackend(config=config, make_client=make_client)
 
     url = codeartifact_pypi_url("domain", "000000000000", "region", "name")
     credentials = backend.get_credential(url, None)
@@ -140,4 +124,77 @@ def test_get_credential_supported_host():
     assert credentials.username == "aws"
     assert credentials.password == "TOKEN"
 
-    client.stub.assert_no_pending_responses()
+
+@pytest.mark.parametrize(
+    ("configuration", "assertions"),
+    [
+        # The effective default options.
+        (
+            """
+            # Empty configuration file.
+            """,
+            {
+                "region_name": "region",
+                "profile_name": None,
+                "aws_access_key_id": None,
+                "aws_secret_access_key": None,
+            },
+        ),
+        # Overriding profile and providing access/secret keys.
+        (
+            """
+            [codeartifact]
+            profile_name = PROFILE-NAME
+            aws_access_key_id = ACCESS-KEY-ID
+            aws_secret_access_key = SECRET-ACCESS-KEY
+            """,
+            {
+                "profile_name": "PROFILE-NAME",
+                "aws_access_key_id": "ACCESS-KEY-ID",
+                "aws_secret_access_key": "SECRET-ACCESS-KEY",
+            },
+        ),
+        # Only accepting both access/secret keys together.
+        (
+            """
+            [codeartifact]
+            aws_access_key_id = ACCESS-KEY-ID
+            """,
+            {
+                "aws_access_key_id": None,
+                "aws_secret_access_key": None,
+            },
+        ),
+        # Overriding profile name in multi-block configuration.
+        (
+            """
+            [codeartifact]
+            profile_name = DEFAULT-PROFILE
+
+            [codeartifact name="name"]
+            profile_name = PROFILE-OVERRIDDEN
+            """,
+            {
+                "profile_name": "PROFILE-OVERRIDDEN",
+            },
+        ),
+    ],
+)
+def test_backend_default_options(configuration, assertions):
+    class DummyClient:
+        def get_authorization_token(self, *args, **kwargs):
+            return {}
+
+    def make_client(options, **kwargs):
+        # Assert that we received specific options.
+        for key, value in assertions.items():
+            assert options.get(key) == value
+
+        # Ignore the rest.
+        return DummyClient()
+
+    with config_from_string(configuration) as config_file:
+        config = CodeArtifactKeyringConfig(config_file=config_file.name)
+        backend = CodeArtifactBackend(config=config, make_client=make_client)
+        url = codeartifact_pypi_url("domain", "000000000000", "region", "name")
+        credentials = backend.get_credential(url, None)


### PR DESCRIPTION
This PR refactors the unit testing mechanism again and fixes a bug where the `profile_name` option was not being used. 