### PR TITLE
Fix GitHub Actions Workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,15 @@ name: 📦 Release 'keyrings.codeartifact' package.
 on: push
 
 jobs:
-  release:
-    name: 📦 Build and publish package.
-
+  build:
+    name: 📦 Build package.
     runs-on: ubuntu-latest
-
-    permissions:
-      id-token: write
 
     steps:
     - name: 🛒 Checkout repository source code.
       uses: actions/checkout@v4
       with:
-        # Always fetch the full repository.
+        persist-credentials: false
         fetch-depth: 0
 
     - name: ✨ Setup Python 3.x environment.
@@ -34,14 +30,64 @@ jobs:
     - name: 🛠️ Build package and source distribution.
       run: |
         python3 -m pip install --user build
-        python3 -m build --sdist --wheel --outdir dist/
+        python3 -m build
 
-    - name: 🚀 Publish package to test PyPI index.
+    - name: 💾 Store the built package distributions.
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-testpypi:
+    name: 🚀 Publish distributions to test PyPI index.
+    runs-on: ubuntu-latest
+
+    needs:
+    - build
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/keyrings.codeartifact
+
+    permissions:
+      # IMPORTANT: mandatory for trusted publishing
+      id-token: write
+
+    steps:
+    - name: 📥 Download the built package distributions.
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: 🚀 Publish distributions to TestPyPI.
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
         skip-existing: true
 
+  publish-to-pypi:
+    name: 🚀 Publish distributions to main PyPI index.
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    runs-on: ubuntu-latest
+
+    needs:
+    - build
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/keyrings.codeartifact
+
+    permissions:
+      # IMPORTANT: mandatory for trusted publishing
+      id-token: write
+
+    steps:
+    - name: 📥 Download the built package distributions.
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
     - name: 🚀 Publish package to main PyPI index.
       uses: pypa/gh-action-pypi-publish@release/v1
-      if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
This PR enables Dependabot updates and reworks the Github Actions workflow to adopt new publishing practices.