### PR TITLE
Authenticate using codeartifact token via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ hosted within CodeArtifact. It will use any appropriate AWS credentials provided
 --index-url https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/pypi/${REPOSITORY}/simple/
 ```
 
+### Environment Variable
+
+You can bypass AWS API calls by setting the `CODEARTIFACT_AUTH_TOKEN` environment variable:
+
+```bash
+# Set the environment variable with a valid token
+export CODEARTIFACT_AUTH_TOKEN=your-auth-token-here
+
+# Then use pip/twine as usual, and the token will be used automatically
+pip install package-name --index-url https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/pypi/${REPOSITORY}/simple/
+```
+
+This is especially useful in CI/CD environments or when you want to avoid making AWS API calls.
+
 Config
 ------
 This backend provides a number of configuration options to modify the behaviour of the AWS client.

--- a/keyrings/codeartifact.py
+++ b/keyrings/codeartifact.py
@@ -1,5 +1,6 @@
 # codeartifact.py -- keyring backend
 
+import os
 import re
 import logging
 
@@ -176,6 +177,12 @@ class CodeArtifactBackend(backend.KeyringBackend):
             region=region,
             name=repository_name,
         )
+
+        # Check for token in environment variable
+        token_from_env = os.getenv("CODEARTIFACT_AUTH_TOKEN")
+        if token_from_env:
+            logging.info("Using token from environment variable: CODEARTIFACT_AUTH_TOKEN")
+            return token_from_env
 
         # Options for the client callback.
         options = {

--- a/keyrings/codeartifact.py
+++ b/keyrings/codeartifact.py
@@ -146,8 +146,13 @@ class CodeArtifactBackend(backend.KeyringBackend):
 
     def get_password(self, service, username):
 
-        # Get the environment variable name from config, default to CODEARTIFACT_AUTH_TOKEN
-        env_variable_name = self.config.get("env_variable", "CODEARTIFACT_AUTH_TOKEN")
+        # Get the environment variable name from config defaults (if provided),
+        # otherwise fall back to the standard CODEARTIFACT_AUTH_TOKEN.
+        # Note: self.config is a CodeArtifactKeyringConfig, not a dict.
+        env_variable_name = (
+            getattr(self.config, "defaults", {})
+            .get("env_variable", "CODEARTIFACT_AUTH_TOKEN")
+        )
 
         # Check for token in environment variable
         token_from_env = os.getenv(env_variable_name)

--- a/keyrings/codeartifact.py
+++ b/keyrings/codeartifact.py
@@ -146,10 +146,13 @@ class CodeArtifactBackend(backend.KeyringBackend):
 
     def get_password(self, service, username):
 
+        # Get the environment variable name from config, default to CODEARTIFACT_AUTH_TOKEN
+        env_variable_name = self.config.get("env_variable", "CODEARTIFACT_AUTH_TOKEN")
+
         # Check for token in environment variable
-        token_from_env = os.getenv("CODEARTIFACT_AUTH_TOKEN")
+        token_from_env = os.getenv(env_variable_name)
         if token_from_env:
-            logging.info("Using token from environment variable: CODEARTIFACT_AUTH_TOKEN")
+            logging.info(f"Using token from environment variable: {env_variable_name}")
             return token_from_env
         
         url = urlparse(service)

--- a/keyrings/codeartifact.py
+++ b/keyrings/codeartifact.py
@@ -145,6 +145,13 @@ class CodeArtifactBackend(backend.KeyringBackend):
             return credentials.SimpleCredential("aws", authorization_token)
 
     def get_password(self, service, username):
+
+        # Check for token in environment variable
+        token_from_env = os.getenv("CODEARTIFACT_AUTH_TOKEN")
+        if token_from_env:
+            logging.info("Using token from environment variable: CODEARTIFACT_AUTH_TOKEN")
+            return token_from_env
+        
         url = urlparse(service)
 
         # Do a quick check to see if this service URL applies to us.
@@ -177,12 +184,6 @@ class CodeArtifactBackend(backend.KeyringBackend):
             region=region,
             name=repository_name,
         )
-
-        # Check for token in environment variable
-        token_from_env = os.getenv("CODEARTIFACT_AUTH_TOKEN")
-        if token_from_env:
-            logging.info("Using token from environment variable: CODEARTIFACT_AUTH_TOKEN")
-            return token_from_env
 
         # Options for the client callback.
         options = {

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -170,4 +170,24 @@ def test_backend_default_options(configuration, assertions):
         config = CodeArtifactKeyringConfig(config_file=config_file.name)
         backend = CodeArtifactBackend(config=config, make_client=make_client)
         url = codeartifact_pypi_url("domain", "000000000000", "region", "name")
-        credentials = backend.get_credential(url, None)
+        backend.get_credential(url, None)
+
+
+def test_get_credential_from_env(monkeypatch):
+    """
+    Tests that the backend can retrieve a token from an environment variable.
+    """
+    monkeypatch.setenv("CODEARTIFACT_AUTH_TOKEN", "ENV_TOKEN")
+
+    def make_client(options):
+        # This should not be called when token is in env
+        pytest.fail("make_client should not be called when token is in env")
+
+    config = CodeArtifactKeyringConfig(config_file=StringIO())
+    backend = CodeArtifactBackend(config=config, make_client=make_client)
+
+    url = codeartifact_pypi_url("domain", "000000000000", "region", "name")
+    credentials = backend.get_credential(url, None)
+
+    assert credentials.username == "aws"
+    assert credentials.password == "ENV_TOKEN"


### PR DESCRIPTION
This pull request introduces support for using an environment variable (`CODEARTIFACT_AUTH_TOKEN`) to bypass AWS API calls when interacting with CodeArtifact, enhancing usability in CI/CD environments and simplifying token management. The changes include updates to documentation, backend logic, and test cases.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R26-R39): Added instructions for setting the `CODEARTIFACT_AUTH_TOKEN` environment variable to bypass AWS API calls, with examples for usage in CI/CD environments.

### Backend Logic Enhancements:
* [`keyrings/codeartifact.py`](diffhunk://#diff-b826bb69a2cf12b8184eb81cca663aa40aac73a97692f0b34112fbd0963edd89R181-R186): Updated the `get_password` method to check for the `CODEARTIFACT_AUTH_TOKEN` environment variable and use it if available, logging the usage for transparency.
* [`keyrings/codeartifact.py`](diffhunk://#diff-b826bb69a2cf12b8184eb81cca663aa40aac73a97692f0b34112fbd0963edd89R3): Imported the `os` module to support environment variable retrieval.

### Testing Improvements:
* [`tests/test_backend.py`](diffhunk://#diff-31e088e0e9d455d2164fd6251e7c23a77afc5561b3746cdf83e08d6a05142154R172-R193): Added a new test case (`test_get_credential_from_env`) to verify that the backend can retrieve credentials from the `CODEARTIFACT_AUTH_TOKEN` environment variable and bypass client creation when the variable is set.