### PR TITLE
ci: move test and lint jobs to blacksmith runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on: push
 jobs:
   build:
     name: 📦 Build and test package.
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
     - name: 🛒 Checkout repository source code.
@@ -24,7 +24,7 @@ jobs:
 
     - name: 🔬 Execute all unit tests.
       run: |
-        python3 -m pip install .[test]
+        python3 -m pip install '.[test]'
         python3 -m pytest
 
     - name: 🛠️ Build package and source distribution.
@@ -40,7 +40,7 @@ jobs:
 
   publish-to-testpypi:
     name: 🚀 Publish package to test PyPI index.
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     needs:
     - build
@@ -69,7 +69,7 @@ jobs:
   publish-to-pypi:
     name: 🚀 Publish package to main PyPI index.
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     needs:
     - build
@@ -96,7 +96,7 @@ jobs:
   publish-github-release:
     name: 🚀 Publish package to GitHub release.
     if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     needs:
     - build


### PR DESCRIPTION
## Why

Two backends run our GitHub Actions jobs, and neither fits test and lint work.
GitHub-hosted minutes bill outside our AWS credits and have run dry before. The
CodeBuild test runners sit against a hard AWS quota of 15 concurrent ARM/Small
and 15 ARM/Large in us-east-2; AWS declined our request to raise it on
2026-07-01, so we cannot buy more headroom.

Blacksmith boots a microVM in under 3 seconds and costs about half of a GitHub
minute. Its cache is transparent, so `actions/cache` needs no change.

## What changed

The `runs-on` label. Comments that named a CodeBuild concept were reworded to
describe the runner the job actually gets.

vCPU is matched 1:1. Blacksmith arm carries more RAM at every tier than the
CodeBuild equivalent (4 vCPU is 12 GB against 8 GB, 8 vCPU is 24 GB against
16 GB), so the known oxlint OOM risk goes down.

| Before | After |
| --- | --- |
| `ubuntu-latest` | `blacksmith-2vcpu-ubuntu-2404` |
| CodeBuild SMALL | `blacksmith-2vcpu-ubuntu-2404-arm` |
| `instance-size:medium` | `blacksmith-4vcpu-ubuntu-2404-arm` |
| `instance-size:large` | `blacksmith-8vcpu-ubuntu-2404-arm` |

## Not in this change

Docker image builds keep the CodeBuild runners. Their BuildKit registry cache
lives in ECR in the same region, so that traffic is free and fast today.

## Verification

Two canary PRs proved both architectures before this batch: truvo/truvo-gtm#49
on x64 and truvo/devcontainer#96 on arm64. A Blacksmith runner picked the job
up in 1.0s.

Every changed workflow here passes `actionlint` locally against the same label
config the org-wide check uses.

Fixes ENG-3420

🤖 Generated with [Claude Code](https://claude.com/claude-code)